### PR TITLE
bugfix/team24-79

### DIFF
--- a/client/src/components/Site.tsx
+++ b/client/src/components/Site.tsx
@@ -87,7 +87,7 @@ function Site(props: SiteInterface) {
   );
   const [floors, setFloors] = useState<number[]>([]);
 
-  const [floorExists, setFloorExists] = useState<boolean>(false);
+  const [floorExists, setFloorExists] = useState<boolean>(true);
   const [infoPanelId, setInfoPanelId] = useState<string>("");
   const [infoPanelOpen, setInfoPanelOpen] = useState<boolean>(false);
   const [minimapEnlarged, setMinimapEnlarged] = useState<boolean>(false);


### PR DESCRIPTION
Fixed the bug where the user cannot go to a specific site from the HomePage.
![image](https://github.com/UQ-eLIPSE/prism/assets/121275444/9ee6c7a6-ceec-4faa-8338-9b8ae4307737)

This was due to creating a Marzipano instance while the container with `id="pano` hasn't rendered yet. As a result, it tried to locate the container, which is null, and apply a style to it (More specifically, overflow hidden". An additional condition was added to the creation of the Marzipano object, that is the same condition to render the pano container.

