### PR TITLE
Feature/team24 129

### DIFF
--- a/client/src/components/Minimap.tsx
+++ b/client/src/components/Minimap.tsx
@@ -14,7 +14,7 @@ import NodeCollection from "./NodeCollection";
 import FloorDetailsForm from "./FloorDetailsForm";
 import ToggleEditNodeButton from "./ToggleEditNodeButton";
 import MinimapImage from "./MiniMapImage";
-import SubmitOrCancelOptions from "./SubmitOrCancelOptions";
+import SubmitOrCancelButtons from "./SubmitOrCancelButtons";
 
 /**
  * This interface represents the current node's position and rotation in the minimap.
@@ -431,7 +431,7 @@ function Minimap(props: MinimapProps) {
                   </label>
                 </div>
               )}
-              <SubmitOrCancelOptions
+              <SubmitOrCancelButtons
                 showCondition={
                   pendingUpload && !props.minimapEnlarged && user?.isAdmin
                 }

--- a/client/src/components/SubmitOrCancelButtons.tsx
+++ b/client/src/components/SubmitOrCancelButtons.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-interface SubmitOrCancelOptionsProps {
+interface SubmitOrCancelButtonsProps {
   showCondition?: boolean;
   handleSubmit: () => void | Promise<void>;
   handleCancel: () => void;
@@ -11,11 +11,11 @@ interface SubmitOrCancelOptionsProps {
  * Renders even if showCondition prop is not provided.
  * @returns {JSX.Element} Submit or Cancel options
  */
-const SubmitOrCancelOptions = ({
+const SubmitOrCancelButtons = ({
   showCondition = true,
   handleSubmit,
   handleCancel,
-}: SubmitOrCancelOptionsProps): JSX.Element | null => {
+}: SubmitOrCancelButtonsProps): JSX.Element | null => {
   return showCondition ? (
     <>
       <div className="submit-update" onClick={handleSubmit}>
@@ -28,4 +28,4 @@ const SubmitOrCancelOptions = ({
   ) : null;
 };
 
-export default SubmitOrCancelOptions;
+export default SubmitOrCancelButtons;


### PR DESCRIPTION
A small refactor in `Minimap` component.
Added a component that handles submission or cancel functionality. When jest/vitest is introduced, this component can then be tested and used everywhere in codebase.

**Setup:**
1. `git fetch`.
2. `git checkout feature/TEAM24-129`
3. go to `localhost:3000/site`.

**Testing:**
1. Try clicking the "Update Minimap" button on the bottom right corner.
2. Try uploading any image file. The submit and cancel button should appear. Try clicking cancel. The minimap image should have disappear. Refresh the browser and the old minimap version should be there.
3. If you have time to mongorestore your db, try submitting the image. The minimap image should be displayed as the one you submitted. If it doesn't try refreshing the browser.
4. `yarn cypress:run:local` should pass all the test. Currently, one test in `TimelineUITest` shouldn't be working but Mohamad is working on a fix for that. It is not this refactor change causing it.
5. Make sure to read README if you're running on some projects. i.e. agco360 requires `yarn cypress:run:local-agco360`