### PR TITLE
bugfix/TEAM24-207

### DIFF
--- a/client/cypress/e2e/ScenenameTest.cy.ts
+++ b/client/cypress/e2e/ScenenameTest.cy.ts
@@ -13,8 +13,7 @@ testEachZone((zone: Cypress.PrismZone) => {
           .parent("[class^='_minimap_nodeContainer']")
           .should("exist")
           .parent()
-          .children("div")
-          .eq(1)
+          .children("div[class*='nodeTitle']")
           .should("exist")
           .invoke("text")
           .then((text) => {


### PR DESCRIPTION
fix the test ScenenameTest.cy.ts
To test on your local:
1. run project on your local
2. restore prism_uat_v0 dataset and switch `db.site_settings.updateMany({}, {$set:{"enable.hotspots_nav": true}})`
3. navigate to client with `cd client`
4. run test 'yarn cypress:run:local-uwmt --spec cypress/e2e/ScenenameTest.cy.ts --headed --no-exit`
should pass the test.
To test on UAT:
1. navigate to client with `cd client`
2. run `yarn cypress:run:uat-uwmt --spec cypress/e2e/ScenenameTest.cy.ts --headed --no-exit`